### PR TITLE
update bcftools to 1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:xenial
+MAINTAINER Thomas B. Mooney <tmooney@genome.wustl.edu>
+
+LABEL \
+  version="1.9" \
+  description="bcftools image for use in Workflows"
+
+RUN apt-get update && apt-get install -y \
+  bzip2 \
+  g++ \
+  libbz2-dev \
+  liblzma-dev \
+  make \
+  ncurses-dev \
+  wget \
+  zlib1g-dev
+
+ENV BCFTOOLS_INSTALL_DIR=/opt/bcftools
+ENV BCFTOOLS_VERSION=1.9
+
+WORKDIR /tmp
+RUN wget https://github.com/samtools/bcftools/releases/download/$BCFTOOLS_VERSION/bcftools-$BCFTOOLS_VERSION.tar.bz2 && \
+  tar --bzip2 -xf bcftools-$BCFTOOLS_VERSION.tar.bz2
+
+WORKDIR /tmp/bcftools-$BCFTOOLS_VERSION
+RUN make prefix=$BCFTOOLS_INSTALL_DIR && \
+  make prefix=$BCFTOOLS_INSTALL_DIR install
+
+WORKDIR /
+RUN ln -s $BCFTOOLS_INSTALL_DIR/bin/bcftools /usr/bin/bcftools && \
+  rm -rf /tmp/bcftools-$BCFTOOLS_VERSION
+
+ENTRYPOINT ["/usr/bin/bcftools"]


### PR DESCRIPTION
adding new image for bcftools version 1.9. Moved the version to an environment variable to help simplify future updates. 

had to add 2 new depencencies for errors during the make process:
libbz2-dev for `fatal error: bzlib.h: No such file or directory`
liblzma-dev for `fatal error: lzma.h: No such file or directory`

Once merged to master will create a branch for 1.9. And after a docker image is created will make a PR at https://github.com/genome/docker-bcftools-cwl to create an image without an entrypoint to be used in cwl workflows
